### PR TITLE
Remove dependency on `object.entries` to make 11ty leaner

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "evaluate-value": "^2.0.0",
     "http-equiv-refresh": "^2.0.1",
     "list-to-array": "^1.1.0",
-    "object.entries": "^1.1.7",
     "parse-srcset": "^1.0.2"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 "use strict";
-const entries = require("object.entries");
 const {expect} = require("chai");
 const {filter} = require("./lib/defaultOptions");
 const plugin = require("./lib");
@@ -9,7 +8,7 @@ const voidTags = require("html-tags/void");
 
 
 
-const fixturesWithAttributes = entries(filter).reduce((result, [tagName, attrs]) =>
+const fixturesWithAttributes = Object.entries(filter).reduce((result, [tagName, attrs]) =>
 {
 	Object.keys(attrs).forEach(attrName =>
 	{


### PR DESCRIPTION
The `object.entries` shim is not necessary - even 11ty version 1x requires a recent enough NodeJS that it's safe to assume `Object.entries` exists. Tests are [only run](https://github.com/11ty/eleventy-posthtml-urls/commit/76a600f1e2ceb53dedb72548fec9d3299ef3a460) on Node 18 and 20 anyway, and the dependency is only used in the test.js file. 

Removing this dependency would get rid of the longest branch in 11ty's dependency tree. This reduces the risk of supply chain attacks, makes installs faster and is better for the environment.

https://npmgraph.js.org/?q=%4011ty%2Feleventy#zoom=w&select=exact%3Aobject.entries%401.1.8

![image](https://github.com/user-attachments/assets/37cc2108-a271-4e0a-8f2f-549c2e45754b)
