### PR TITLE
Switch from parse-srcset to srcset

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -161,8 +161,8 @@ filteredFixturesWithAttributes.forEach(({attrName, isVoid, tagName}) => it(`supp
 
 ["img", "source"].forEach(tagName => it(`supports <${tagName} src srcset="…">`, () =>
 {
-	const input  = `<${tagName} src="image1.png" srcset="image1a.png 2x, image1b.png 100w, image1c.png 100h">`;
-	const output = `<${tagName} src="http://domain.com/image1.png" srcset="http://domain.com/image1a.png 2x, http://domain.com/image1b.png 100w, http://domain.com/image1c.png 100h">`;
+	const input  = `<${tagName} src="image1.png" srcset="image1a.png 2x, image1b.png 100w, image1c.png">`;
+	const output = `<${tagName} src="http://domain.com/image1.png" srcset="http://domain.com/image1a.png 2x, http://domain.com/image1b.png 100w, http://domain.com/image1c.png">`;
 
 	const options =
 	{

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 const DEFAULT_OPTIONS = require("./defaultOptions");
 const parseMetaRefresh = require("http-equiv-refresh");
-const parseSrcset = require("parse-srcset");
+const { parseSrcset } = require("srcset");
 
 const CONTENT_ATTR = "content";
 const PING_ATTR = "ping";
@@ -148,14 +148,13 @@ const transformSrcset = (node, attrName, transformer) =>
 
 	if (values.length > 0)
 	{
-		const promises = values.map(({d, h, url, w}) => Promise.resolve( transformer(url, attrName, tag, node) )
+		const promises = values.map(({density, url, width}) => Promise.resolve( transformer(url, attrName, tag, node) )
 		.then(newUrl =>
 		{
-			d = d !== undefined ? ` ${d}x` : EMPTY_STRING;
-			h = h !== undefined ? ` ${h}h` : EMPTY_STRING;
-			w = w !== undefined ? ` ${w}w` : EMPTY_STRING;
+			density = density !== undefined ? ` ${density}x` : EMPTY_STRING;
+			width = width !== undefined ? ` ${width}w` : EMPTY_STRING;
 
-			return `${newUrl}${w}${h}${d}`;
+			return `${newUrl}${width}${density}`;
 		}));
 
 		return Promise.all(promises).then(newValues => attrs[attrName] = newValues.join(PRETTY_DELIMITER));

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,12 @@
 "use strict";
 const DEFAULT_OPTIONS = require("./defaultOptions");
 const parseMetaRefresh = require("http-equiv-refresh");
-const { parseSrcset } = require("srcset");
+const { parseSrcset, stringifySrcset } = require("srcset");
 
 const CONTENT_ATTR = "content";
 const PING_ATTR = "ping";
 const SRCSET_ATTR = "srcset";
 
-const EMPTY_STRING = "";
 const EMPTY_TAG_GROUP = Object.freeze({});
 const FUNCTION_TYPE = "function";
 const PRETTY_DELIMITER = ", ";
@@ -148,16 +147,16 @@ const transformSrcset = (node, attrName, transformer) =>
 
 	if (values.length > 0)
 	{
-		const promises = values.map(({density, url, width}) => Promise.resolve( transformer(url, attrName, tag, node) )
-		.then(newUrl =>
+		const promises = values.map((srcset) => Promise.resolve( transformer(srcset.url, attrName, tag, node) )
+		.then(
+    /** @returns {import('srcset').SrcSetDefinition} */
+    newUrl =>
 		{
-			density = density !== undefined ? ` ${density}x` : EMPTY_STRING;
-			width = width !== undefined ? ` ${width}w` : EMPTY_STRING;
-
-			return `${newUrl}${width}${density}`;
+      
+			return { ...srcset, url: newUrl };
 		}));
 
-		return Promise.all(promises).then(newValues => attrs[attrName] = newValues.join(PRETTY_DELIMITER));
+		return Promise.all(promises).then(newValues => attrs[attrName] = stringifySrcset(newValues));
 	}
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "http-equiv-refresh": "^2.0.1",
-        "parse-srcset": "^1.0.2"
+        "srcset": "^5.0.3"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.5",
@@ -1282,12 +1282,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
-      "license": "MIT"
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1433,6 +1427,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/srcset": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.3.tgz",
+      "integrity": "sha512-AZswtOXIsu0LeHdo6YY7d0r2pCH2Rl1D8ae1utvXUX4GxG3RggsVUAOFX1r8RI4YHFMYb4g89+UBPBv3mNUU2g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stackback": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   },
   "dependencies": {
     "http-equiv-refresh": "^2.0.1",
-    "parse-srcset": "^1.0.2"
+    "srcset": "^5.0.3"
   },
   "devDependencies": {
-    "vitest": "^4.1.5",
     "@vitest/coverage-v8": "^4.1.5",
     "html-tags": "^3.1.1",
-    "posthtml": "~0.16.6"
+    "posthtml": "~0.16.6",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">= 20"


### PR DESCRIPTION
Follow-up to #4.

This _removes_ the support for srcset specifiers like `100h`, which parse-srcset supports and srcset does not. The background is that the `h` specifier was a proposed part of the spec removed at least six years ago and [removed from srcset](https://github.com/sindresorhus/srcset/pull/6) and other parsers as a result.

Otherwise, does the same thing. srcset includes a stringifier, so I'm using that too to make the most of using a module.